### PR TITLE
Fixed broken link

### DIFF
--- a/main/zoe/guide/contracts/pricedCallSpread.md
+++ b/main/zoe/guide/contracts/pricedCallSpread.md
@@ -2,7 +2,9 @@
 
 <Zoe-Version/>
 
-##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/callSpread/pricedCallSpreads.js)
+
+
+##### [View the code on Github](https://github.com/Agoric/agoric-sdk/blob/master/packages/zoe/src/contracts/callSpread/pricedCallSpread.js)
 ##### [View all contracts on Github](https://github.com/Agoric/agoric-sdk/tree/master/packages/zoe/src/contracts)
 
 This contract implements a fully collateralized call spread. You can use a call spread as a


### PR DESCRIPTION
updated the link to pricedCallSpread.js to point to the correct links. somehow an `s` got appended onto the end but seems all good now 👍